### PR TITLE
Use built-in String.prototype.trim()

### DIFF
--- a/lib/generate-title.js
+++ b/lib/generate-title.js
@@ -1,6 +1,4 @@
 const striptags = require('striptags')
-const trimRight = require('trim-right')
-const trimLeft = require('trim-left')
 
 /**
  *  Generate the required atom title for a JSON feed item
@@ -19,7 +17,7 @@ module.exports = function generateTitle (item) {
  * Removes title unfriendly whitespace
  */
 function cleanWhitespace (str) {
-  return trimLeft(trimRight(str.split('\n')[0]))
+  return str.split('\n')[0].trim()
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
   },
   "dependencies": {
     "striptags": "^3.1.1",
-    "trim-left": "^1.0.1",
-    "trim-right": "^1.0.1",
     "xmlbuilder": "^9.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
I couldn't find a reason for using these modules, but maybe I missed something?