### PR TITLE
Add <logo> to output XML

### DIFF
--- a/jsonfeed-to-atom-object.js
+++ b/jsonfeed-to-atom-object.js
@@ -47,6 +47,7 @@ module.exports = function jsonfeedToAtomObject (jf, opts) {
     '#text': packageInfo.name
   }
   if (jf.favicon || jf.icon) atom.feed.icon = jf.favicon || jf.icon
+  if (jf.icon) atom.feed.logo = jf.icon
   if (jf.author && jf.author.name) atom.feed.rights = `© ${now.getFullYear()} ${jf.author.name}`
   if (jf.description) atom.feed.subtitle = jf.description
 

--- a/snapshot.json
+++ b/snapshot.json
@@ -35,6 +35,7 @@
    "#text": "jsonfeed-to-atom"
   },
   "icon": "https://bret.io/favicon-64x64.png",
+  "logo": "https://bret.io/icon-512x512.png",
   "rights": "© 2018 Bret Comnes",
   "subtitle": "A running log of announcements, projects and accomplishments.",
   "entry": [

--- a/snapshot.xml
+++ b/snapshot.xml
@@ -13,6 +13,7 @@
   </author>
   <generator uri="https://github.com/bcomnes/jsonfeed-to-atom#readme" version="1.1.2">jsonfeed-to-atom</generator>
   <icon>https://bret.io/favicon-64x64.png</icon>
+  <logo>https://bret.io/icon-512x512.png</logo>
   <rights>© 2018 Bret Comnes</rights>
   <subtitle>A running log of announcements, projects and accomplishments.</subtitle>
   <entry>


### PR DESCRIPTION
I think we should use `icon` in the JSONfeed when present and generate a `<logo>` in the output.

`<logo>` is defined in [the spec](https://validator.w3.org/feed/docs/atom.html) as:

"Identifies a larger image which provides visual identification for the feed."

So:

"favicon" (json) -> "icon" (xml)
"icon" (json) -> "logo" (xml)